### PR TITLE
Update CfgWeapons.hpp

### DIFF
--- a/main/CfgWeapons.hpp
+++ b/main/CfgWeapons.hpp
@@ -86,23 +86,23 @@ class cfgWeapons
 	};	
 	
 	class fow_w_m1a1_thompson : fow_rifle_base {
-		magazines[] = {"fow_30Rnd_45acp", "fow_30Rnd_45acp_T","LIB_30Rnd_45ACP"};
+		magazines[] = {"fow_30Rnd_45acp", "fow_30Rnd_45acp_T","LIB_30Rnd_45ACP","LIB_30Rnd_45ACP_t"};
 	};	
 	class LIB_M1A1_Thompson : LIB_SMG {
-		magazines[] = {"fow_30Rnd_45acp", "fow_30Rnd_45acp_T","LIB_30Rnd_45ACP"};
+		magazines[] = {"fow_30Rnd_45acp", "fow_30Rnd_45acp_T","LIB_30Rnd_45ACP","LIB_30Rnd_45ACP_t"};
 	};
 	class LIB_M1928_Thompson : LIB_M1A1_Thompson {
-		magazines[] = {"fow_30Rnd_45acp", "fow_30Rnd_45acp_T","LIB_30Rnd_45ACP", "LIB_50Rnd_45ACP"};
+		magazines[] = {"fow_30Rnd_45acp", "fow_30Rnd_45acp_T","LIB_30Rnd_45ACP","LIB_30Rnd_45ACP_t","LIB_50Rnd_45ACP"};
 	};
 	class LIB_M1928A1_Thompson : LIB_M1928_Thompson {
-		magazines[] = {"fow_30Rnd_45acp", "fow_30Rnd_45acp_T","LIB_30Rnd_45ACP"};
+		magazines[] = {"fow_30Rnd_45acp", "fow_30Rnd_45acp_T","LIB_30Rnd_45ACP","LIB_30Rnd_45ACP_t","LIB_50Rnd_45ACP"};
 	};
 	
 	class fow_w_m3 : fow_rifle_base {
-		magazines[] = {"fow_30Rnd_45acp", "fow_30Rnd_45acp_T"};
+		magazines[] = {"fow_30Rnd_45acp", "fow_30Rnd_45acp_T","LIB_30Rnd_M3_GreaseGun_45ACP"};
 	};	
 	class LIB_M3_GreaseGun : LIB_SMG {
-		magazines[] = {"fow_30Rnd_45acp", "fow_30Rnd_45acp_T","LIB_30Rnd_45ACP", "LIB_30Rnd_45ACP_t"};
+		magazines[] = {"fow_30Rnd_45acp", "fow_30Rnd_45acp_T","LIB_30Rnd_M3_GreaseGun_45ACP"};
 	};
 	
 	class fow_w_g43 : fow_rifle_base {
@@ -140,8 +140,8 @@ class cfgWeapons
 		magazines[] = {"fow_5Rnd_762x63","LIB_5Rnd_762x63", "LIB_5Rnd_762x63_t"};
 	};
 
-	class fow_w_fg42 : Pistol_Base_F {
-		magazines[] = {"fow_20Rnd_792x57","LIB_20Rnd_792x57"};
+	class fow_w_fg42 : Rifle_Base_F {
+		magazines[] = {"fow_20Rnd_792x57","LIB_20Rnd_792x57",};
 	};
 	class LIB_FG42G : LIB_RIFLE {
 		magazines[] = {"fow_20Rnd_792x57","LIB_20Rnd_792x57"};

--- a/main/CfgWeapons.hpp
+++ b/main/CfgWeapons.hpp
@@ -8,6 +8,7 @@ class cfgWeapons
 	class LIB_P38;
 	class LIB_LAUNCHER;
 	class LIB_RIFLE;
+	class LIB_SRIFLE;
 	class LIB_LMG;
 	class LIB_SMG;
 	class LIB_PISTOL;
@@ -24,6 +25,9 @@ class cfgWeapons
 		magazines[] = {"lib_5Rnd_792x57", "lib_5Rnd_792x57_t", "lib_5Rnd_792x57_sS", "lib_5Rnd_792x57_SMK","fow_5Rnd_792x57"};
 	};
 	class LIB_K98 : LIB_RIFLE {
+		magazines[] = {"lib_5Rnd_792x57", "lib_5Rnd_792x57_t", "lib_5Rnd_792x57_sS", "lib_5Rnd_792x57_SMK","fow_5Rnd_792x57",};
+	};
+	class LIB_K98ZF39 : LIB_SRIFLE {
 		magazines[] = {"lib_5Rnd_792x57", "lib_5Rnd_792x57_t", "lib_5Rnd_792x57_sS", "lib_5Rnd_792x57_SMK","fow_5Rnd_792x57",};
 	};
 	
@@ -111,6 +115,10 @@ class cfgWeapons
 	class LIB_G43 : LIB_RIFLE {
 		magazines[] = {"lib_10Rnd_792x57","fow_10nd_792x57","lib_5Rnd_792x57","fow_5Rnd_792x57","lib_5Rnd_792x57_t","lib_5Rnd_792x57_sS", "lib_5Rnd_792x57_SMK", "lib_10Rnd_792x57_T", "lib_10Rnd_792x57_T2", "lib_10Rnd_792x57_sS", "lib_10Rnd_792x57_SMK"}; 
 	};
+	
+	class LIB_G41 : LIB_RIFLE {
+		magazines[] = {"LIB_10Rnd_792x57_clip","lib_5Rnd_792x57", "lib_5Rnd_792x57_t", "lib_5Rnd_792x57_sS", "lib_5Rnd_792x57_SMK","fow_5Rnd_792x57"};
+	};
 
 	class fow_w_m1911 : Pistol_Base_F {
 		magazines[] = {"LIB_7Rnd_45ACP","fow_7Rnd_45acp"};
@@ -137,6 +145,9 @@ class cfgWeapons
 		magazines[] = {"LIB_5Rnd_762x63", "LIB_5Rnd_762x63_t","fow_5Rnd_762x63"};
 	};
 	class LIB_M1903A3_Springfield : LIB_RIFLE {
+		magazines[] = {"LIB_5Rnd_762x63", "LIB_5Rnd_762x63_t","fow_5Rnd_762x63"};
+	};
+	class LIB_M1903A4_Springfield : LIB_SRIFLE {
 		magazines[] = {"LIB_5Rnd_762x63", "LIB_5Rnd_762x63_t","fow_5Rnd_762x63"};
 	};
 

--- a/main/CfgWeapons.hpp
+++ b/main/CfgWeapons.hpp
@@ -140,7 +140,7 @@ class cfgWeapons
 		magazines[] = {"fow_5Rnd_762x63","LIB_5Rnd_762x63", "LIB_5Rnd_762x63_t"};
 	};
 
-	class fow_w_fg42 : Rifle_Base_F {
+	class fow_w_fg42 : fow_rifle_base {
 		magazines[] = {"fow_20Rnd_792x57","LIB_20Rnd_792x57",};
 	};
 	class LIB_FG42G : LIB_RIFLE {

--- a/main/CfgWeapons.hpp
+++ b/main/CfgWeapons.hpp
@@ -21,130 +21,130 @@ class cfgWeapons
 	};
 	
 	class fow_w_k98 : fow_rifleBolt_base {
-		magazines[] = {"fow_5Rnd_792x57","lib_5Rnd_792x57", "lib_5Rnd_792x57_t", "lib_5Rnd_792x57_sS", "lib_5Rnd_792x57_SMK"};
+		magazines[] = {"lib_5Rnd_792x57", "lib_5Rnd_792x57_t", "lib_5Rnd_792x57_sS", "lib_5Rnd_792x57_SMK","fow_5Rnd_792x57"};
 	};
 	class LIB_K98 : LIB_RIFLE {
-		magazines[] = {"fow_5Rnd_792x57","lib_5Rnd_792x57", "lib_5Rnd_792x57_t", "lib_5Rnd_792x57_sS", "lib_5Rnd_792x57_SMK"};
+		magazines[] = {"lib_5Rnd_792x57", "lib_5Rnd_792x57_t", "lib_5Rnd_792x57_sS", "lib_5Rnd_792x57_SMK","fow_5Rnd_792x57",};
 	};
 	
 	class fow_w_mg42 : fow_rifle_base {
-		magazines[] = {"fow_50Rnd_792x57","lib_50Rnd_792x57","lib_50Rnd_792x57_SMK","lib_50Rnd_792x57_sS"};
+		magazines[] = {"lib_50Rnd_792x57","lib_50Rnd_792x57_SMK","lib_50Rnd_792x57_sS","fow_50Rnd_792x57"};
 	};
 	class LIB_MG42 : LIB_LMG {
-		magazines[] = {"fow_50Rnd_792x57","lib_50Rnd_792x57","lib_50Rnd_792x57_SMK","lib_50Rnd_792x57_sS"};
+		magazines[] = {"lib_50Rnd_792x57","lib_50Rnd_792x57_SMK","lib_50Rnd_792x57_sS","fow_50Rnd_792x57"};
 	};
 	class fow_w_mg34 : fow_rifle_base {
-		magazines[] = {"fow_50Rnd_792x57","lib_50Rnd_792x57","lib_50Rnd_792x57_SMK","lib_50Rnd_792x57_sS"};
+		magazines[] = {"lib_50Rnd_792x57","lib_50Rnd_792x57_SMK","lib_50Rnd_792x57_sS","fow_50Rnd_792x57"};
 	};
 	class LIB_MG34 : LIB_LMG {
-		magazines[] = {"fow_50Rnd_792x57","lib_50Rnd_792x57","lib_50Rnd_792x57_SMK","lib_50Rnd_792x57_sS"};
+		magazines[] = {"lib_50Rnd_792x57","lib_50Rnd_792x57_SMK","lib_50Rnd_792x57_sS","fow_50Rnd_792x57"};
 	};	
 	
 	class fow_w_mp40 : fow_rifle_base {
-		magazines[] = {"fow_32Rnd_9x19_mp40","LIB_32rnd_9x19", "LIB_32rnd_9x19_t"};
+		magazines[] = {"LIB_32rnd_9x19", "LIB_32rnd_9x19_t","fow_32Rnd_9x19_mp40"};
 	};
 	class LIB_MP40 : LIB_SMG {
-		magazines[] = {"fow_32Rnd_9x19_mp40","LIB_32rnd_9x19", "LIB_32rnd_9x19_t"};
+		magazines[] = {"LIB_32rnd_9x19", "LIB_32rnd_9x19_t","fow_32Rnd_9x19_mp40"};
 	};
 	class LIB_MP38 : LIB_SMG {
-		magazines[] = {"fow_32Rnd_9x19_mp40","LIB_32rnd_9x19", "LIB_32rnd_9x19_t"};
+		magazines[] = {"LIB_32rnd_9x19", "LIB_32rnd_9x19_t","fow_32Rnd_9x19_mp40"};
 	};
 	
 	class fow_w_stg44 : fow_rifle_base {
-		magazines[] = {"fow_30Rnd_792x33","LIB_30rnd_792x33", "LIB_30rnd_792x33_t"};
+		magazines[] = {"LIB_30rnd_792x33", "LIB_30rnd_792x33_t","fow_30Rnd_792x33"};
 	};
 	class LIB_MP44 : LIB_RIFLE {
-		magazines[] = {"fow_30Rnd_792x33","LIB_30rnd_792x33", "LIB_30rnd_792x33_t"};
+		magazines[] = {"LIB_30rnd_792x33", "LIB_30rnd_792x33_t","fow_30Rnd_792x33"};
 	};	
 	
 	class fow_w_m1_carbine : fow_rifle_base {
-		magazines[] = {"fow_15Rnd_762x33","LIB_15Rnd_762x33", "LIB_15Rnd_762x33_t"};	
+		magazines[] = {"LIB_15Rnd_762x33", "LIB_15Rnd_762x33_t","fow_15Rnd_762x33"};	
 	};	
 	class LIB_M1_Carbine : LIB_RIFLE {
-		magazines[] = {"fow_15Rnd_762x33","LIB_15Rnd_762x33", "LIB_15Rnd_762x33_t"};	
+		magazines[] = {"LIB_15Rnd_762x33", "LIB_15Rnd_762x33_t","fow_15Rnd_762x33"};	
 	};
 	
 	class fow_w_m1_garand : fow_rifle_base {
-		magazines[] = {"fow_8Rnd_762x63","LIB_8Rnd_762x63", "LIB_8Rnd_762x63_t"};
+		magazines[] = {"LIB_8Rnd_762x63", "LIB_8Rnd_762x63_t","fow_8Rnd_762x63"};
 	};	
 	class LIB_M1_Garand : LIB_RIFLE {
-		magazines[] = {"fow_8Rnd_762x63","LIB_8Rnd_762x63", "LIB_8Rnd_762x63_t"};
+		magazines[] = {"LIB_8Rnd_762x63", "LIB_8Rnd_762x63_t","fow_8Rnd_762x63"};
 	};	
 	
 	class fow_w_m1918a2 : fow_rifle_base {
-		magazines[] = {"fow_20Rnd_762x63","LIB_20Rnd_762x63"};
+		magazines[] = {"LIB_20Rnd_762x63","fow_20Rnd_762x63"};
 	};	
 	class LIB_M1918A2_BAR : LIB_LMG {
-		magazines[] = {"fow_20Rnd_762x63","LIB_20Rnd_762x63"};
+		magazines[] = {"LIB_20Rnd_762x63","fow_20Rnd_762x63"};
 	};
 	
 	class fow_w_m1919 : fow_rifle_base {
-		magazines[] = {"fow_30Rnd_762x63","fow_50Rnd_762x63","LIB_50Rnd_762x63"};
+		magazines[] = {"LIB_50Rnd_762x63","fow_30Rnd_762x63","fow_50Rnd_762x63"};
 	};	
 	class LIB_M1919A4 : LIB_LMG {
-		magazines[] = {"fow_30Rnd_762x63","fow_50Rnd_762x63","LIB_50Rnd_762x63"};
+		magazines[] = {"LIB_50Rnd_762x63","fow_30Rnd_762x63","fow_50Rnd_762x63"};
 	};	
 	
 	class fow_w_m1a1_thompson : fow_rifle_base {
-		magazines[] = {"fow_30Rnd_45acp", "fow_30Rnd_45acp_T","LIB_30Rnd_45ACP","LIB_30Rnd_45ACP_t"};
+		magazines[] = {"LIB_30Rnd_45ACP","LIB_30Rnd_45ACP_t","fow_30Rnd_45acp", "fow_30Rnd_45acp_T"};
 	};	
 	class LIB_M1A1_Thompson : LIB_SMG {
-		magazines[] = {"fow_30Rnd_45acp", "fow_30Rnd_45acp_T","LIB_30Rnd_45ACP","LIB_30Rnd_45ACP_t"};
+		magazines[] = {"LIB_30Rnd_45ACP","LIB_30Rnd_45ACP_t","fow_30Rnd_45acp", "fow_30Rnd_45acp_T"};
 	};
 	class LIB_M1928_Thompson : LIB_M1A1_Thompson {
-		magazines[] = {"fow_30Rnd_45acp", "fow_30Rnd_45acp_T","LIB_30Rnd_45ACP","LIB_30Rnd_45ACP_t","LIB_50Rnd_45ACP"};
+		magazines[] = {"LIB_50Rnd_45ACP","LIB_30Rnd_45ACP","LIB_30Rnd_45ACP_t","fow_30Rnd_45acp", "fow_30Rnd_45acp_T"};
 	};
 	class LIB_M1928A1_Thompson : LIB_M1928_Thompson {
-		magazines[] = {"fow_30Rnd_45acp", "fow_30Rnd_45acp_T","LIB_30Rnd_45ACP","LIB_30Rnd_45ACP_t","LIB_50Rnd_45ACP"};
+		magazines[] = {"LIB_50Rnd_45ACP","LIB_30Rnd_45ACP","LIB_30Rnd_45ACP_t","fow_30Rnd_45acp", "fow_30Rnd_45acp_T"};
 	};
 	
 	class fow_w_m3 : fow_rifle_base {
-		magazines[] = {"fow_30Rnd_45acp", "fow_30Rnd_45acp_T","LIB_30Rnd_M3_GreaseGun_45ACP"};
+		magazines[] = {"LIB_30Rnd_M3_GreaseGun_45ACP","fow_30Rnd_45acp", "fow_30Rnd_45acp_T"};
 	};	
 	class LIB_M3_GreaseGun : LIB_SMG {
-		magazines[] = {"fow_30Rnd_45acp", "fow_30Rnd_45acp_T","LIB_30Rnd_M3_GreaseGun_45ACP"};
+		magazines[] = {"LIB_30Rnd_M3_GreaseGun_45ACP","fow_30Rnd_45acp", "fow_30Rnd_45acp_T"};
 	};
 	
 	class fow_w_g43 : fow_rifle_base {
-		magazines[] = {"fow_10nd_792x57","lib_10Rnd_792x57", "lib_5Rnd_792x57", "lib_5Rnd_792x57_t", "lib_5Rnd_792x57_sS", "lib_5Rnd_792x57_SMK", "lib_10Rnd_792x57_T", "lib_10Rnd_792x57_T2", "lib_10Rnd_792x57_sS", "lib_10Rnd_792x57_SMK"}; 
+		magazines[] = {"lib_10Rnd_792x57","fow_10nd_792x57","lib_5Rnd_792x57","fow_5Rnd_792x57","lib_5Rnd_792x57_t","lib_5Rnd_792x57_sS", "lib_5Rnd_792x57_SMK", "lib_10Rnd_792x57_T", "lib_10Rnd_792x57_T2", "lib_10Rnd_792x57_sS", "lib_10Rnd_792x57_SMK"}; 
 	};
 	class LIB_G43 : LIB_RIFLE {
-		magazines[] = {"fow_10nd_792x57","lib_10Rnd_792x57", "lib_5Rnd_792x57", "lib_5Rnd_792x57_t", "lib_5Rnd_792x57_sS", "lib_5Rnd_792x57_SMK", "lib_10Rnd_792x57_T", "lib_10Rnd_792x57_T2", "lib_10Rnd_792x57_sS", "lib_10Rnd_792x57_SMK"}; 
+		magazines[] = {"lib_10Rnd_792x57","fow_10nd_792x57","lib_5Rnd_792x57","fow_5Rnd_792x57","lib_5Rnd_792x57_t","lib_5Rnd_792x57_sS", "lib_5Rnd_792x57_SMK", "lib_10Rnd_792x57_T", "lib_10Rnd_792x57_T2", "lib_10Rnd_792x57_sS", "lib_10Rnd_792x57_SMK"}; 
 	};
 
 	class fow_w_m1911 : Pistol_Base_F {
-		magazines[] = {"fow_7Rnd_45acp","LIB_7Rnd_45ACP"};
+		magazines[] = {"LIB_7Rnd_45ACP","fow_7Rnd_45acp"};
 	};
 	class LIB_Colt_M1911 : LIB_PISTOL {
-		magazines[] = {"fow_7Rnd_45acp","LIB_7Rnd_45ACP"};
+		magazines[] = {"LIB_7Rnd_45ACP","fow_7Rnd_45acp"};
 	};
 	
 	class fow_w_ppk : Pistol_Base_F {
-		magazines[] = {"fow_8Rnd_9x19","LIB_7Rnd_9x19"};
+		magazines[] = {"LIB_7Rnd_9x19","fow_8Rnd_9x19"};
 	};
 	class LIB_WaltherPPK : LIB_PISTOL {
-		magazines[] = {"fow_8Rnd_9x19","LIB_7Rnd_9x19"};
+		magazines[] = {"LIB_7Rnd_9x19","fow_8Rnd_9x19"};
 	};
 	
 	class fow_w_p08 : Pistol_Base_F {
-		magazines[] = {"fow_8Rnd_9x19","LIB_8Rnd_9x19_P08"};
+		magazines[] = {"LIB_8Rnd_9x19_P08","fow_8Rnd_9x19"};
 	};	
 	class LIB_P08 : LIB_P38 {
-		magazines[] = {"fow_8Rnd_9x19","LIB_8Rnd_9x19_P08"};
+		magazines[] = {"LIB_8Rnd_9x19_P08","fow_8Rnd_9x19"};
 	};	
 	
 	class fow_w_m1903A1 : fow_rifleBolt_base {
-		magazines[] = {"fow_5Rnd_762x63","LIB_5Rnd_762x63", "LIB_5Rnd_762x63_t"};
+		magazines[] = {"LIB_5Rnd_762x63", "LIB_5Rnd_762x63_t","fow_5Rnd_762x63"};
 	};
 	class LIB_M1903A3_Springfield : LIB_RIFLE {
-		magazines[] = {"fow_5Rnd_762x63","LIB_5Rnd_762x63", "LIB_5Rnd_762x63_t"};
+		magazines[] = {"LIB_5Rnd_762x63", "LIB_5Rnd_762x63_t","fow_5Rnd_762x63"};
 	};
 
 	class fow_w_fg42 : fow_rifle_base {
-		magazines[] = {"fow_20Rnd_792x57","LIB_20Rnd_792x57",};
+		magazines[] = {"LIB_20Rnd_792x57","fow_20Rnd_792x57"};
 	};
 	class LIB_FG42G : LIB_RIFLE {
-		magazines[] = {"fow_20Rnd_792x57","LIB_20Rnd_792x57"};
+		magazines[] = {"LIB_20Rnd_792x57","fow_20Rnd_792x57"};
 	};
 
 	// Vehicles weapons


### PR DESCRIPTION
1. Fow FG42 was as pistol
2. M3 use now m3 mag not thomson
3. M1928A1 can now  use also  50 rnd
4. All Thomson can use IFA3 45 acp  tracers
5. Fow mag should work in IFA3 weapons
6. G41 can use 5rnd from k98